### PR TITLE
add database default values to template

### DIFF
--- a/deploy/linux/roles/upload/templates/deploy.config.j2
+++ b/deploy/linux/roles/upload/templates/deploy.config.j2
@@ -5,9 +5,9 @@
   "dependencies":
   {{ dependencies | to_json }},
   "database": {
-    "user": "{{ database_user }}",
-    "password": "{{ database_password }}",
-    "host": "{{ database_host }}",
-    "port": "{{ database_port }}"
+    "user": "{{ database_user | default("") }}",
+    "password": "{{ database_password | default ("") }}",
+    "host": "{{ database_host | default("") }}",
+    "port": "{{ database_port | default("") }}"
   }
 }


### PR DESCRIPTION
this should prevent ansible from complaining when someone is deploying nodetron (w/o a database).