### PR TITLE
Deploy with pm2

### DIFF
--- a/deploy/linux/pm2/roles/start/tasks/cronjob.yml
+++ b/deploy/linux/pm2/roles/start/tasks/cronjob.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Read optional cronjob.json file
+  shell: cat "/home/{{ ansible_user }}/{{ service_id }}/cronjob.json"
+  register: cronjob_file
+  ignore_errors: yes
+
+- name: Parsing cronjob.json file
+  set_fact:
+    cronjob_json: "{{ cronjob_file.stdout | from_json }}"
+  when: cronjob_file is defined
+  ignore_errors: yes
+
+- name: Print out cronjob.json content
+  debug:
+    msg: "Read the cronjob.json file with {{ cronjob_json }}"
+  when: cronjob_json is defined
+
+- name: Adding crontab entries
+  shell: "( crontab -l | grep -v -F '{{ item.job }}' || : ; echo '{{ item.frequency }} {{ item.job }}' ) | crontab -"
+  loop: "{{ cronjob_json }}"
+  when: cronjob_json is defined and (item.root is not defined or item.root == false)
+
+- name: Adding root crontab entries
+  shell: "( crontab -l | grep -v -F '{{ item.job }}' || : ; echo '{{ item.frequency }} {{ item.job }}' ) | crontab -"
+  become: yes
+  loop: "{{ cronjob_json }}"
+  when: cronjob_json is defined and item.root is defined and item.root == true

--- a/deploy/linux/pm2/roles/start/tasks/main.yml
+++ b/deploy/linux/pm2/roles/start/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- fail:
+    msg: "service_id is required"
+  when: service_id is not defined
+
+- include_tasks: cronjob.yml

--- a/deploy/linux/pm2/roles/start/tasks/main.yml
+++ b/deploy/linux/pm2/roles/start/tasks/main.yml
@@ -4,4 +4,7 @@
     msg: "service_id is required"
   when: service_id is not defined
 
+- name: start pm2
+  shell: cd /home/{{ ansible_user }}/{{ service_id }}; pm2 start server.js -- config/app_config.json
+
 - include_tasks: cronjob.yml

--- a/deploy/linux/pm2/roles/stop/tasks/main.yml
+++ b/deploy/linux/pm2/roles/stop/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- fail:
+    msg: "service_id is required"
+  when: service_id is not defined

--- a/deploy/linux/pm2/roles/stop/tasks/main.yml
+++ b/deploy/linux/pm2/roles/stop/tasks/main.yml
@@ -3,3 +3,7 @@
 - fail:
     msg: "service_id is required"
   when: service_id is not defined
+
+- name: stop pm2
+  shell: cd /home/{{ ansible_user }}/{{ service_id }}; pm2 stop server.js
+  ignore_errors: true

--- a/deploy/linux/pm2/roles/upload/tasks/create_artifact_params.yml
+++ b/deploy/linux/pm2/roles/upload/tasks/create_artifact_params.yml
@@ -1,0 +1,29 @@
+---
+
+- block:
+  - name: Create artifact file
+    file:
+      path: /tmp/var.json
+      state: touch
+
+  - name: Load var from file
+    include_vars:
+      file: /tmp/var.json
+      name: temp_json
+
+  - name: Creating artifact JSON key/values
+    set_fact:
+      artifact_json: "{{ temp_json | default([]) | combine({
+        'service_id': '{{ service_id }}',
+        'params': {
+            'stderr_path': '/home/{{ ansible_user }}/{{ service_id }}/stderr.log',
+            'stdout_path': '/home/{{ ansible_user }}/{{ service_id }}/stdout.log'
+        }
+        })
+      }}"
+
+  - name: write var to file
+    copy:
+      content: "{{ artifact_json | to_nice_json }}"
+      dest: "{{ output_path }}/artifact.json"
+  delegate_to: localhost

--- a/deploy/linux/pm2/roles/upload/tasks/main.yml
+++ b/deploy/linux/pm2/roles/upload/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+- debug:
+    msg: Upload {{ service_id }} service
+
+- fail:
+    msg: "service_id is required"
+  when: service_id is not defined
+
+- fail:
+    msg: "service_port is required"
+  when: service_port is not defined
+
+- name: defaulting delay_start_ms
+  set_fact:
+    delay_start_ms: 0
+  when: delay_start_ms is not defined
+
+- include_tasks: sync_service.yml
+
+- name: Check app_config.json exist
+  stat:
+    path: ~/{{ service_id }}/config/app_config.json
+  register: app_config_exist
+
+- template:
+    src: deploy.config.j2
+    dest: ~/{{ service_id }}/config/app_config.json
+  when: app_config_exist.stat.exists == False
+
+- include_tasks: create_artifact_params.yml

--- a/deploy/linux/pm2/roles/upload/tasks/sync_service.yml
+++ b/deploy/linux/pm2/roles/upload/tasks/sync_service.yml
@@ -1,0 +1,19 @@
+--- 
+
+- name: "Create {{ service_id }} directory"
+  file:
+    path: ~/{{ service_id }}
+    state: directory
+
+- synchronize: 
+    dest: ~/{{ service_id }}
+    src: ../../../../../engine/
+    rsync_opts:
+      - "--exclude=node_modules/*"
+      - "--exclude=.git*"
+      - "--exclude=README.md*"
+
+- name: NPM install
+  command: bash -lc "npm install"
+  args: 
+    chdir: ~/{{ service_id }}

--- a/deploy/linux/pm2/roles/upload/templates/deploy.config.j2
+++ b/deploy/linux/pm2/roles/upload/templates/deploy.config.j2
@@ -1,0 +1,14 @@
+{
+  "id" : "{{ service_id }}",
+  "port" : {{ service_port }},
+  "delayStartMs": {{ delay_start_ms }},
+  "dependencies":
+  {{ dependencies | to_json }},
+  "database": {
+    "user": "{{ database_user | default("") }}",
+    "password": "{{ database_password | default ("") }}",
+    "host": "{{ database_host | default("") }}",
+    "port": "{{ database_port | default("") }}",
+    "name": "{{ service_id }}"
+  }
+}


### PR DESCRIPTION
## Summary

Adding a new deploy method for using pm2 instead of supervisord.

Note, this does NOT install pm2, it only makes use of it assuming it is already installed.
If PM2 is NOT installed, the deployment will fail.

## Checklist
- [ ] Documentation updated
- [ ] Unit tests updated
- [ ] User Acceptance Tests updated

## Deployment Configuration for Testing

## Related Issues

## Related Pull Requests

## Reviewers
cc @gabeobrien @aswanson-nr 
